### PR TITLE
fixed another DI issue

### DIFF
--- a/src/FloppyBot.Commands.Core/Support/Hybrid/CooldownTask.cs
+++ b/src/FloppyBot.Commands.Core/Support/Hybrid/CooldownTask.cs
@@ -25,11 +25,13 @@ public class CooldownTask : IHybridTask
     public CooldownTask(
         ILogger<CooldownTask> logger,
         ICooldownService cooldownService,
-        ITimeProvider timeProvider)
+        ITimeProvider timeProvider,
+        ICommandConfigurationService commandConfigurationService)
     {
         _logger = logger;
         _cooldownService = cooldownService;
         _timeProvider = timeProvider;
+        _commandConfigurationService = commandConfigurationService;
     }
 
     public bool ExecutePre(CommandInfo info, CommandInstruction instruction)


### PR DESCRIPTION
Fixes this stack trace:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at FloppyBot.Commands.Core.Support.Hybrid.CooldownTask.ExtractCooldownFromConfiguration(String channelId, String command, PrivilegeLevel userPrivilegeLevel) in /src/FloppyBot.Commands.Core/Support/Hybrid/CooldownTask.cs:line 92
   at FloppyBot.Commands.Core.Support.Hybrid.CooldownTask.DetermineCooldown(CommandInfo info, ChatMessage sourceMessage) in /src/FloppyBot.Commands.Core/Support/Hybrid/CooldownTask.cs:line 79
   at FloppyBot.Commands.Core.Support.Hybrid.CooldownTask.ExecutePre(CommandInfo info, CommandInstruction instruction) in /src/FloppyBot.Commands.Core/Support/Hybrid/CooldownTask.cs:line 38
   at FloppyBot.Commands.Core.Support.SupportingTaskExtensions.<>c__DisplayClass5_0.<RunPreExecutionTasks>b__0(IPreExecutionTask t) in /src/FloppyBot.Commands.Core/Support/SupportingTaskExtensions.cs:line 57
   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at FloppyBot.Commands.Core.Support.SupportingTaskExtensions.RunPreExecutionTasks(IServiceScope scope, CommandInfo info, CommandInstruction instruction) in /src/FloppyBot.Commands.Core/Support/SupportingTaskExtensions.cs:line 55
   at FloppyBot.Commands.Core.Spawner.CommandSpawner.<>c__DisplayClass4_0.<SpawnAndExecuteCommand>b__0() in /src/FloppyBot.Commands.Core/Spawner/CommandSpawner.cs:line 71
   at FloppyBot.Base.Extensions.TryExtensions.TryOr[T](Func`1 supplier, Action`1 exceptionHandler) in /src/FloppyBot.Base.Extensions/TryExtensions.cs:line 9
```