### PR TITLE
Fixed Web API

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
       - dependency-name: "System.*"
         versions:
           - "version-update:semver-major"
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "microsoft/*"
+        versions:
+          - "version-update:semver-major"

--- a/src/FloppyBot.WebApi.Agent/Dockerfile
+++ b/src/FloppyBot.WebApi.Agent/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
+﻿FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
 COPY ./out /app
 COPY ./app-version /app/version
 WORKDIR /app


### PR DESCRIPTION
Observed the following issue:

```
You must install or update .NET to run this application.

App: /app/FloppyBot.WebApi.Agent.dll
Architecture: x64
Framework: 'Microsoft.AspNetCore.App', version '6.0.0' (x64)
.NET location: /usr/share/dotnet/

No frameworks were found.

Learn about framework resolution:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.AspNetCore.App&framework_version=6.0.0&arch=x64&rid=debian.11-x64
```