### PR TITLE
Update InstanceNameEnricher for proper property addition

### DIFF
--- a/src/FloppyBot.Base.Logging/Enrichers/InstanceNameEnricher.cs
+++ b/src/FloppyBot.Base.Logging/Enrichers/InstanceNameEnricher.cs
@@ -15,6 +15,10 @@ public class InstanceNameEnricher : ILogEventEnricher
 
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
-        propertyFactory.CreateProperty("FloppyBotInstanceName", _instanceName);
+        var instanceNameProperty = propertyFactory.CreateProperty(
+            "FloppyBotInstanceName",
+            _instanceName
+        );
+        logEvent.AddOrUpdateProperty(instanceNameProperty);
     }
 }


### PR DESCRIPTION
The InstanceNameEnricher class was updated to not just create a new log event property for "FloppyBotInstanceName", but also to add or update this property in the existing log event. This allows for more flexible and accurate logging of the instance name, improving troubleshooting and monitoring capacities.