### PR TITLE
feat: now producing events for channel point redemptions

### DIFF
--- a/src/FloppyBot.Chat.Agent/floppybot.json
+++ b/src/FloppyBot.Chat.Agent/floppybot.json
@@ -36,6 +36,7 @@
     "AccessToken": "",
     "DisableWhenChannelIsOffline": true,
     "MonitorInterface": 30,
-    "AnnounceChannelOnlineStatus": true
+    "AnnounceChannelOnlineStatus": true,
+    "EnableTwitchEventSource": false
   }
 }

--- a/src/FloppyBot.Chat.Twitch.Events/TwitchChannelPointsRewardRedeemedEvent.cs
+++ b/src/FloppyBot.Chat.Twitch.Events/TwitchChannelPointsRewardRedeemedEvent.cs
@@ -1,0 +1,16 @@
+using FloppyBot.Chat.Entities;
+
+namespace FloppyBot.Chat.Twitch.Events;
+
+public record TwitchChannelPointsRewardRedeemedEvent(
+    string EventId,
+    ChatUser User,
+    TwitchChannelPointsReward Reward
+) : TwitchEvent(TwitchEventTypes.CHANNEL_POINTS_REWARD_REDEEMED);
+
+public record TwitchChannelPointsReward(
+    string RewardId,
+    string Title,
+    string Prompt,
+    int PointCost
+);

--- a/src/FloppyBot.Chat.Twitch.Events/TwitchEventTypes.cs
+++ b/src/FloppyBot.Chat.Twitch.Events/TwitchEventTypes.cs
@@ -7,6 +7,7 @@ public static class TwitchEventTypes
     public const string SUBSCRIPTION_GIFT = "Twitch.SubscriptionGift";
     public const string SUBSCRIPTION_GIFT_COMMUNITY = "Twitch.SubscriptionGiftCommunity";
     public const string RAID = "Twitch.Raid";
+    public const string CHANNEL_POINTS_REWARD_REDEEMED = "Twitch.ChannelPointRewardRedeemed";
 
     public const string USER_JOINED = "Twitch.UserJoined";
     public const string USER_LEFT = "Twitch.UserLeft";

--- a/src/FloppyBot.Chat.Twitch.Tests/TwitchChatInterfaceTests.cs
+++ b/src/FloppyBot.Chat.Twitch.Tests/TwitchChatInterfaceTests.cs
@@ -9,6 +9,7 @@ using FloppyBot.Chat.Entities.Identifiers;
 using FloppyBot.Chat.Twitch.Api;
 using FloppyBot.Chat.Twitch.Config;
 using FloppyBot.Chat.Twitch.Events;
+using FloppyBot.Chat.Twitch.EventSources;
 using FloppyBot.Chat.Twitch.Monitor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TwitchLib.Client;
@@ -35,6 +36,7 @@ public class TwitchChatInterfaceTests
         "anaccesstoken",
         false,
         0,
+        false,
         false
     );
 
@@ -229,7 +231,8 @@ public class TwitchChatInterfaceTests
             _client,
             _configuration,
             _onlineMonitor,
-            A.Fake<ITwitchApiService>()
+            A.Fake<ITwitchApiService>(),
+            A.Fake<ITwitchEventSource>()
         );
     }
 

--- a/src/FloppyBot.Chat.Twitch/Config/Registration.cs
+++ b/src/FloppyBot.Chat.Twitch/Config/Registration.cs
@@ -1,4 +1,5 @@
 using FloppyBot.Chat.Twitch.Api;
+using FloppyBot.Chat.Twitch.EventSources;
 using FloppyBot.Chat.Twitch.Monitor;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,6 +12,7 @@ using TwitchLib.Client.Models;
 using TwitchLib.Communication.Clients;
 using TwitchLib.Communication.Interfaces;
 using TwitchLib.Communication.Models;
+using TwitchLib.EventSub.Websockets.Extensions;
 
 namespace FloppyBot.Chat.Twitch.Config;
 
@@ -62,6 +64,17 @@ public static class Registration
             })
             .AddSingleton<ITwitchChannelOnlineMonitor, TwitchChannelOnlineMonitor>()
             .AddSingleton<ITwitchApiService, TwitchApiService>()
+            // - Event Source
+            .AddTwitchLibEventSubWebsockets()
+            .AddSingleton<NoopTwitchEventSource>()
+            .AddSingleton<TwitchEventSource>()
+            .AddSingleton<ITwitchEventSource>(p =>
+            {
+                var config = p.GetRequiredService<TwitchConfiguration>();
+                return config.EnableTwitchEventSource
+                    ? p.GetRequiredService<TwitchEventSource>()
+                    : p.GetRequiredService<NoopTwitchEventSource>();
+            })
             // - Chat Interface
             .AddSingleton<IChatInterface, TwitchChatInterface>();
     }

--- a/src/FloppyBot.Chat.Twitch/Config/TwitchConfiguration.cs
+++ b/src/FloppyBot.Chat.Twitch/Config/TwitchConfiguration.cs
@@ -8,14 +8,24 @@ public record TwitchConfiguration(
     string AccessToken,
     bool DisableWhenChannelIsOffline,
     int MonitorInterval,
-    bool AnnounceChannelOnlineStatus
+    bool AnnounceChannelOnlineStatus,
+    bool EnableTwitchEventSource
 )
 {
     [Obsolete("This constructor is only present for configuration purposes and should not be used")]
     // ReSharper disable once UnusedMember.Global
     public TwitchConfiguration()
-        : this(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, true, 30, true)
-    { }
+        : this(
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            true,
+            30,
+            true,
+            false
+        ) { }
 
     public bool HasTwitchApiCredentials =>
         !string.IsNullOrWhiteSpace(ClientId) && !string.IsNullOrWhiteSpace(AccessToken);

--- a/src/FloppyBot.Chat.Twitch/EventSources/TwitchEventSource.cs
+++ b/src/FloppyBot.Chat.Twitch/EventSources/TwitchEventSource.cs
@@ -1,0 +1,186 @@
+using FloppyBot.Chat.Twitch.Api;
+using FloppyBot.Chat.Twitch.Config;
+using FloppyBot.Chat.Twitch.Events;
+using FloppyBot.Chat.Twitch.Extensions;
+using Microsoft.Extensions.Logging;
+using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+using TwitchLib.EventSub.Websockets;
+using TwitchLib.EventSub.Websockets.Core.EventArgs;
+using TwitchLib.EventSub.Websockets.Core.EventArgs.Channel;
+
+namespace FloppyBot.Chat.Twitch.EventSources;
+
+public interface ITwitchEventSource
+{
+    event EventHandler<TwitchChannelPointsRewardRedeemedEvent> ChannelPointsCustomRewardRedemptionAdd;
+
+    Task ConnectAsync();
+    Task DisconnectAsync();
+}
+
+public class NoopTwitchEventSource : ITwitchEventSource
+{
+    private readonly ILogger<NoopTwitchEventSource> _logger;
+    public event EventHandler<TwitchChannelPointsRewardRedeemedEvent>? ChannelPointsCustomRewardRedemptionAdd;
+
+    public NoopTwitchEventSource(ILogger<NoopTwitchEventSource> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task ConnectAsync()
+    {
+        _logger.LogInformation(
+            "Trying to connect a Noop Twitch Event Source. You will not get any events from Twitch."
+        );
+        return Task.CompletedTask;
+    }
+
+    public Task DisconnectAsync()
+    {
+        return Task.CompletedTask;
+    }
+}
+
+public class TwitchEventSource : ITwitchEventSource, IAsyncDisposable
+{
+    private readonly ILogger<TwitchEventSource> _logger;
+    private readonly ITwitchApiService _twitchApi;
+    private readonly EventSubWebsocketClient _client;
+    private readonly TwitchConfiguration _configuration;
+
+    public event EventHandler<TwitchChannelPointsRewardRedeemedEvent> ChannelPointsCustomRewardRedemptionAdd;
+
+    public TwitchEventSource(
+        ILogger<TwitchEventSource> logger,
+        ITwitchApiService twitchApi,
+        EventSubWebsocketClient client,
+        TwitchConfiguration configuration
+    )
+    {
+        _logger = logger;
+        _client = client;
+        _configuration = configuration;
+        _twitchApi = twitchApi;
+
+        _client.WebsocketConnected += (source, args) =>
+        {
+            try
+            {
+                ClientOnWebsocketConnected(source, args).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unhandled error in event handler ClientOnWebsocketConnected");
+            }
+        };
+        _client.WebsocketDisconnected += ClientOnWebsocketDisconnected;
+        _client.WebsocketReconnected += ClientOnWebsocketReconnected;
+        _client.ErrorOccurred += ClientOnErrorOccurred;
+
+        _client.ChannelPointsCustomRewardRedemptionAdd +=
+            ClientOnChannelPointsCustomRewardRedemptionAdd;
+    }
+
+    public async Task ConnectAsync()
+    {
+        _logger.LogInformation("Connecting to Twitch");
+        await _client.ConnectAsync();
+    }
+
+    public async Task DisconnectAsync()
+    {
+        _logger.LogInformation("Disconnecting from Twitch");
+        await _client.DisconnectAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!string.IsNullOrWhiteSpace(_client.SessionId))
+        {
+            await DisconnectAsync();
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private void ClientOnErrorOccurred(object? sender, ErrorOccuredArgs e)
+    {
+        _logger.LogError(e.Exception, "Twitch Event error: {ErrorMessage}", e.Message);
+    }
+
+    private async Task ClientOnWebsocketConnected(object? sender, WebsocketConnectedArgs e)
+    {
+        _logger.LogInformation("Connected to Twitch");
+        if (e.IsRequestedReconnect)
+        {
+            return;
+        }
+
+        try
+        {
+            _logger.LogInformation("Trying to establish channel point redemption subscription");
+            await _twitchApi.CreateChannelPointsRedemptionSubscriptionAsync(
+                _configuration.Channel,
+                _client.SessionId
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to create channel point redemption subscription, no events will be received"
+            );
+        }
+    }
+
+    private void ClientOnWebsocketDisconnected(object? sender, EventArgs e)
+    {
+        _logger.LogWarning("Disconnected from Twitch");
+    }
+
+    private void ClientOnWebsocketReconnected(object? sender, EventArgs e)
+    {
+        _logger.LogInformation("Reconnected to Twitch");
+    }
+
+    private void ClientOnChannelPointsCustomRewardRedemptionAdd(
+        object? sender,
+        ChannelPointsCustomRewardRedemptionArgs e
+    )
+    {
+        // https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchannel_points_custom_reward_redemptionadd
+        var sourceEvent = e.Notification.Payload.Event;
+        if (sourceEvent is null)
+        {
+            _logger.LogWarning(
+                "No notification payload found for {Event}",
+                e.Notification.Metadata.MessageId
+            );
+            return;
+        }
+
+        var eventData = sourceEvent.ConvertToInternalEvent();
+        _logger.LogInformation("Channel Point Reward Redemption added: {@Event}", eventData);
+        ChannelPointsCustomRewardRedemptionAdd?.Invoke(sender, eventData);
+    }
+}
+
+internal static class InternalEventConverters
+{
+    internal static TwitchChannelPointsRewardRedeemedEvent ConvertToInternalEvent(
+        this ChannelPointsCustomRewardRedemption redemption
+    )
+    {
+        return new TwitchChannelPointsRewardRedeemedEvent(
+            redemption.Id,
+            TwitchEntityExtensions.ConvertToChatUser(redemption.UserLogin, redemption.UserName),
+            new TwitchChannelPointsReward(
+                redemption.Reward.Id,
+                redemption.Reward.Title,
+                redemption.Reward.Prompt,
+                redemption.Reward.Cost
+            )
+        );
+    }
+}


### PR DESCRIPTION
Contributes to #314

This is a first, "hail mary" implementation that is mostly aiming to prove the functionality. As such, this feature is hidden behind a flag: `Twitch__EnableTwitchEventSource`

The following functionality (theoretically) exists:
1. Upon connecting to a channel, the Twitch chat agent will attempt to establish an EventSub connection via Websockets
2. Then, it will attempt to create a subscription for channel point redemptions on the channel it was assigned to.
3. If redemptions are received, it will then send out a new event message out via Redis.