### PR TITLE
chore: updated twitch library

### DIFF
--- a/src/FloppyBot.Chat.Twitch/FloppyBot.Chat.Twitch.csproj
+++ b/src/FloppyBot.Chat.Twitch/FloppyBot.Chat.Twitch.csproj
@@ -12,6 +12,7 @@
       Include="Microsoft.Extensions.DependencyInjection.Abstractions"
       Version="10.0.0"
     />
+    <PackageReference Include="TwitchLib.EventSub.Websockets" Version="0.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FloppyBot.Base.Extensions\FloppyBot.Base.Extensions.csproj" />


### PR DESCRIPTION
Updated `TwitchLib.EventSub.Websockets` to the most recent version. The version previously used (implicitly) used a non-existing API endpoint