### PR TITLE
fix: register ITwitchAccessCredentialsService in executor agent

### DIFF
--- a/src/FloppyBot.Commands.Executor.Agent/FloppyBot.Commands.Executor.Agent.csproj
+++ b/src/FloppyBot.Commands.Executor.Agent/FloppyBot.Commands.Executor.Agent.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\FloppyBot.Commands.Aux.Time\FloppyBot.Commands.Aux.Time.csproj" />
     <ProjectReference Include="..\FloppyBot.Commands.Aux.Translation\FloppyBot.Commands.Aux.Translation.csproj" />
     <ProjectReference Include="..\FloppyBot.Commands.Aux.Twitch\FloppyBot.Commands.Aux.Twitch.csproj" />
+    <ProjectReference Include="..\FloppyBot.TwitchApi\FloppyBot.TwitchApi.csproj" />
     <ProjectReference Include="..\FloppyBot.Commands.Aux.UnitConv\FloppyBot.Commands.Aux.UnitConv.csproj" />
     <ProjectReference Include="..\FloppyBot.Commands.Aux.UrbanDictionary\FloppyBot.Commands.Aux.UrbanDictionary.csproj" />
     <ProjectReference Include="..\FloppyBot.Commands.Core\FloppyBot.Commands.Core.csproj" />

--- a/src/FloppyBot.Commands.Executor.Agent/Program.cs
+++ b/src/FloppyBot.Commands.Executor.Agent/Program.cs
@@ -11,6 +11,7 @@ using FloppyBot.Commands.Registry;
 using FloppyBot.Communication.Redis.Config;
 using FloppyBot.HealthCheck.Core;
 using FloppyBot.HealthCheck.KillSwitch;
+using FloppyBot.TwitchApi;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -25,6 +26,7 @@ IHost host = builder
         services
             .AddRedisCommunication()
             .AddMongoDbStorage()
+            .AddTwitchAuth()
             .ScanAndAddCommandDependencies()
             .AddDistributedCommandRegistry()
             .AddCronJobSupport()


### PR DESCRIPTION
## Summary

- `ShoutoutCommand` uses `TwitchApiService` which depends on `ITwitchAccessCredentialsService`
- `ITwitchAccessCredentialsService` is registered by `AddTwitchAuth()`, but this was never called in `Commands.Executor.Agent`
- Fixes `InvalidOperationException` crash when `!shoutout` command is triggered

## Changes

- `Program.cs`: added `AddTwitchAuth()` call and corresponding `using`
- `.csproj`: added project reference to `FloppyBot.TwitchApi`

## Test plan

- [x] `dotnet build` succeeds (0 errors)
- [x] `dotnet test src/FloppyBot.Commands.Aux.Twitch.Tests/` — 11/11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)